### PR TITLE
Add Curve secp256k1

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"math/big"
 
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/miekg/pkcs11"
 	"github.com/pkg/errors"
 )
@@ -83,6 +84,10 @@ var wellKnownCurves = map[string]curveInfo{
 	"P-256": {
 		mustMarshal(asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}),
 		elliptic.P256(),
+	},
+	"secp256k1": {
+		mustMarshal(asn1.ObjectIdentifier{1, 3, 132, 0, 10}),
+		secp256k1.S256(),
 	},
 	"P-384": {
 		mustMarshal(asn1.ObjectIdentifier{1, 3, 132, 0, 34}),

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,6 +44,7 @@ var curves = []elliptic.Curve{
 	elliptic.P256(),
 	elliptic.P384(),
 	elliptic.P521(),
+	secp256k1.S256(),
 	// plus something with explicit parameters
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ThalesIgnite/crypto11
 go 1.13
 
 require (
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,16 @@
 module github.com/ThalesIgnite/crypto11
 
-go 1.13
+go 1.17
 
 require (
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
 	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	github.com/thales-e-security/pool v0.0.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 h1:HbphB4TFFXpv7MNrT52FGrrgVXF1owhMVTHFZIlnvd4=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0/go.mod h1:DZGJHZMqrU4JJqFAWUS2UO1+lbSKsdiOoYi9Zzey7Fc=
 github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f h1:eVB9ELsoq5ouItQBr5Tj334bhPJG/MX+m7rTchmzVUQ=
 github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=


### PR DESCRIPTION
This PR adds support for Elliptic Curve S256, aka secp256k1. The curve is defined in Standards for Efficient Cryptography, [SEC 2: Recommended Elliptic Curve Domain Parameters](https://www.secg.org/sec2-v2.pdf), Section 2.4.1 and commonly used in Blockchain systems, starting with Bitcoin. See Bitcoin Wiki [secp256k1](https://en.bitcoin.it/wiki/Secp256k1).

Go Version Change
Due to the minimum requirement of the library dependency on [github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0](https://github.com/decred/dcrd/tree/dcrec/secp256k1/v4.1.0), this change increases the minimum version of go to 1.17.

PR Additions
a dependency on the library, [github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0](https://github.com/decred/dcrd/tree/dcrec/secp256k1/v4.1.0) which is a copyfree license and [includes the Name in the Curve params, "secp256k1"](https://github.com/decred/dcrd/blob/dcrec/secp256k1/v4.1.0/dcrec/secp256k1/ellipticadaptor.go#L248) which is the same name used by HSMs, such as [AWS Cloud HSM](https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-key-types.html), openssl and SoftHSM2.
the curve asn1.ObjectIdentifier{1, 3, 132, 0, 10} is correct for secp256k1, see [oid-info.com](http://oid-info.com/get/1.3.132.0.10)
The contents of this PR with secp256k1 have been used in an internal project that used SoftHSM2.